### PR TITLE
Make keybind work when numlock is enabled

### DIFF
--- a/src/platform/X/input.c
+++ b/src/platform/X/input.c
@@ -257,7 +257,7 @@ void xgrab_key(uint8_t code, uint8_t mods)
 
 	XGrabKey(dpy,
 		 xcode,
-		 xmods, /* numlock */
+		 xmods | Mod2Mask, /* numlock */
 		 DefaultRootWindow(dpy),
 		 False,
 		 GrabModeAsync, GrabModeAsync);


### PR DESCRIPTION
I found keybinds weren't working when numlock was enabled, I'm assuming this second `XGrabKey` call should check for mod2?