### PR TITLE
Fix bugs when "grid_keys" overlap with "buttons".

### DIFF
--- a/src/grid.c
+++ b/src/grid.c
@@ -124,6 +124,7 @@ struct input_event *grid_mode()
 
 			platform_mouse_move(scr, mx, my);
 			redraw(mx, my, 0);
+			continue;
 		}
 
 		if (config_input_match(ev, "buttons", 0) ||


### PR DESCRIPTION
E.g. "n" is used in "grid_keys" and although buttons was overrided with new keys in config file, the old "n" is still active here.