### PR TITLE
Override default config entry

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -190,7 +190,20 @@ static void config_add(const char *key, const char *val)
 			break;
 
 	}
-
+	// check if key already exists
+	// if so, replace value
+	// if not, add to list
+	int found = 0;
+	struct config_entry *cur = config;
+	while (cur) {
+		if (!strcmp(cur->key, key)) {
+			cur->value = val;
+			free(ent);
+			return;
+		}
+		cur = cur->next;
+	}
+	
 	ent->next = config;
 
 	config = ent;


### PR DESCRIPTION
The default config entry should be overrided by the keys defined in the config file.  In somesituation, the "button" was overrided with "j k ,", in "grid" mode although "grid_keys" was re-config to "l u n h" but "j" and "k" is still behave as "grid_keys" instead of "button" key.