### PR TITLE
wayland: fix virtual mouse position for setups where virtual pointer space doesn't begin at (0, 0)

### DIFF
--- a/src/platform/wayland/wayland.c
+++ b/src/platform/wayland/wayland.c
@@ -3,6 +3,7 @@
  *
  * © 2019 Raheman Vaiya (see also: LICENSE).
  */
+#include <limits.h>
 #include "wayland.h"
 
 #define UNIMPLEMENTED { \
@@ -39,10 +40,10 @@ const char *platform_input_lookup_name(uint8_t code)
 void platform_mouse_move(struct screen *scr, int x, int y)
 {
 	int i;
-	int maxx = 0;
-	int maxy = 0;
-	int minx = 0;
-	int miny = 0;
+	int maxx = INT_MIN;
+	int maxy = INT_MIN;
+	int minx = INT_MAX;
+	int miny = INT_MAX;
 
 	active_screen->ptrx = x;
 	active_screen->ptry = y;


### PR DESCRIPTION
This boils down to unreasonable initial values for computing min/max of positions ranging through all the screens.


This bit me on my Sway setup where I am prepared for two displays but sometimes one of them is not connected. Then, the only display doesn't start at (0,0) and the virtual mouse gets desynchronised with the real one, and I cannot reach some part of the screen with the mouse.

I hope that the patch is correct, as I didn't actually test it on setups with multiple screens attached.