### PR TITLE
Makefile: change default prefix to /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMIT=$(shell git rev-parse --short HEAD)
 VERSION=1.3.4
 DESTDIR=
-PREFIX=/usr
+PREFIX=/usr/local
 
 CFLAGS:=-g\
        -Wall\


### PR DESCRIPTION
/usr/local was supposed to contain programs that are not packaged through the distribution, and on usual setups, /usr/local/bin is already in the PATH.