### PR TITLE
Update list of AUR packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ bindsym Mod4+Mod1+g exec warpd --grid
 
 ## Arch
 
-Available as an [AUR](https://aur.archlinux.org/packages/warpd-git/) package (maintained by Matheus Fillipe).
+Available in the [AUR](https://aur.archlinux.org/): [warpd](https://aur.archlinux.org/packages/warpd/), [warpd-wayland](https://aur.archlinux.org/packages/warpd-wayland), [warpd-git](https://aur.archlinux.org/packages/warpd-git) maintained by Matheus Fillipe.
 
 If you are interesting in adding warpd to your distribution's repository please contact me.
 


### PR DESCRIPTION
I've created a few more packages for this. warpd-git buils from the latest commit while warpd-wayland and warpd build from the latest release.
