### PR TITLE
Adds macos arrow keys to valid keys

### DIFF
--- a/src/platform/macos/input.m
+++ b/src/platform/macos/input.m
@@ -421,6 +421,10 @@ static void update_keymap()
 			case 61: set_name("rightshift")
 			case 62: set_name("rightalt")
 			case 63: set_name("rightcontrol")
+			case 124: set_name("leftarrow")
+			case 127: set_name("uparrow")
+			case 125: set_name("rightarrow")
+			case 126: set_name("downarrow")
 #undef set_name
 		}
 


### PR DESCRIPTION
Simple PR to allow the use of arrow keys to move cursor on macos. I didn't make the same change of linux as I have no idea what I'm doing. 😎 

my motivation for adding these keys is that I use home row modifiers so hjkl aren't viable keys to hold down. I have a function button that turns hjkl into the arrow keys to work around that problem and thus use warped. 