### PR TITLE
add script for creating systemd user service

### DIFF
--- a/warpd-systemd-install.sh
+++ b/warpd-systemd-install.sh
@@ -1,0 +1,5 @@
+sudo cp warpd.service /etc/systemd/user/warpd.service
+
+systemctl --user daemon-reload
+systemctl --user enable warpd.service
+systemctl --user start warpd.service

--- a/warpd.service
+++ b/warpd.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=warpd - A modal keyboard driven interface for mouse manipulation.
+
+[Service]
+ExecStart=/usr/local/bin/warpd -f
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
I created a small script which allows you to setup warpd as a systemd user service. The benefit of this is that now warpd starts automatically(you can disable that if you want to). No need to open new shell and type `warpd` every time you reboot your computer. It is also easier to check its status with `systemctl --user status warpd`. 

Where is the appropriate place to put this script? Or maybe make part of the `make install` for Linux? Should I add a few lines in the README.md about this?